### PR TITLE
Fix/update sample IAM policy for SQS input

### DIFF
--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -40,11 +40,12 @@ require "digest/sha2"
 #           "Action": [
 #             "sqs:ChangeMessageVisibility",
 #             "sqs:ChangeMessageVisibilityBatch",
+#             "sqs:DeleteMessage",
+#             "sqs:DeleteMessageBatch",
 #             "sqs:GetQueueAttributes",
 #             "sqs:GetQueueUrl",
 #             "sqs:ListQueues",
-#             "sqs:SendMessage",
-#             "sqs:SendMessageBatch"
+#             "sqs:ReceiveMessage"
 #           ],
 #           "Effect": "Allow",
 #           "Resource": [


### PR DESCRIPTION
The list of permissions is fine, but their sample IAM policy is actually for a "producer" of messages (output), not a "consumer" (input).
