### PR TITLE
Increase log retention to 3 weeks and add delay compress

### DIFF
--- a/pkg/logrotate.conf
+++ b/pkg/logrotate.conf
@@ -1,8 +1,9 @@
 /var/log/logstash/*.log {
         daily
-        rotate 7
+        rotate 21
         copytruncate
         compress
+        delaycompress
         missingok
         notifempty
 }


### PR DESCRIPTION
We had a Logstash issue when the month of August started that went unnoticed because we were OOO. Unfortunately logrotate only keeps a week of logs so we can't troubleshoot. Let's increase this, and also add deplaycompress, which has been added to the upstream configuration anyway: https://github.com/elastic/logstash/pull/1542
